### PR TITLE
Убран файл зависимостей из игнора при сборке docker образа.

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -4,5 +4,4 @@ node_modules/
 .env
 .env.example
 README.md
-yarn.lock
 nuxt-dist/


### PR DESCRIPTION
При сборке образа необходимо, чтобы файл yarn.lock также попадал в пространство при сборке.