### PR TITLE
Разделен кеш между таблицей и документом

### DIFF
--- a/client/pages/dcis/documents/_documentId.vue
+++ b/client/pages/dcis/documents/_documentId.vue
@@ -112,7 +112,8 @@ export default defineComponent({
         sheetId: activeDocument.value ? activeDocument.value.sheets[activeSheetIndex.value].id : ''
       }),
       options: () => ({
-        enabled: !activeDocumentLoading.value
+        enabled: !activeDocumentLoading.value,
+        fetchPolicy: 'cache-and-network'
       })
     })
 

--- a/client/plugins/apollo.ts
+++ b/client/plugins/apollo.ts
@@ -1,4 +1,4 @@
-import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
+import { InMemoryCache, defaultDataIdFromObject, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
 import { Plugin } from '@nuxt/types'
 import { useRuntimeConfig } from '#app'
 import schema from '~/schema.json'
@@ -13,7 +13,17 @@ export default <Plugin> function (): any {
     httpEndpoint: API_URL,
     browserHttpEndpoint: API_URL_BROWSER,
     wsEndpoint: WS_URL,
-    cache: new InMemoryCache({ fragmentMatcher }),
+    cache: new InMemoryCache({
+      fragmentMatcher,
+      dataIdFromObject (object) {
+        switch (object.__typename) {
+          case 'SheetType': return undefined
+          case 'RowDimensionType': return undefined
+          case 'CellType': return undefined
+          default: return defaultDataIdFromObject(object)
+        }
+      }
+    }),
     httpLinkOptions: {
       headers: {
         'Accept-Language': 'ru' // Язык по умолчанию


### PR DESCRIPTION
Closes #554.
Листы, строки, и ячейки запрашиваются в 2 местах, которые должны лишь частично зависеть друг от друга. Cамым простым и действенным способом исправить проблему, оказалось отключение нормализации для этих типов.
Это создает другую проблему: изменение размера строк и стилей ячеек в таблице не влияет на кеш для документа. Эта проблемы была убрана политикой 'cache-and-network'.
