### PR TITLE
Исправлен баг при удалении проекта и периода

### DIFF
--- a/client/pages/dcis/periods/_periodId/settings.vue
+++ b/client/pages/dcis/periods/_periodId/settings.vue
@@ -190,7 +190,7 @@ export default defineComponent({
         router.push(localePath({
           name: 'dcis-projects-projectId-periods',
           params: { projectId: props.period.project.id },
-          query: { periodId: deletedId }
+          query: { deletePeriodId: deletedId }
         }))
       }
     }

--- a/client/pages/dcis/projects/_projectId/periods.vue
+++ b/client/pages/dcis/projects/_projectId/periods.vue
@@ -66,10 +66,10 @@ export default defineComponent({
     ) => addUpdate(cache, result, 'period')
 
     onMounted(() => {
-      if (route.query.periodId) {
+      if (periods.value && route.query.deletePeriodId) {
         update(
           defaultClient.cache,
-          { data: { deletePeriod: { id: route.query.periodId } } },
+          { data: { deletePeriod: { id: route.query.deletePeriodId } } },
           (cacheData, { data: { deletePeriod: { id: periodId } } }
           ) => {
             cacheData.periods = cacheData.periods.filter(period => period.id !== periodId)

--- a/client/pages/dcis/projects/_projectId/settings.vue
+++ b/client/pages/dcis/projects/_projectId/settings.vue
@@ -156,7 +156,10 @@ export default defineComponent({
 
     const deleteProjectDone = ({ data: { deleteProject: { success } } }: DeleteProjectResultMutation) => {
       if (success) {
-        router.push(localePath({ name: 'dcis-projects', query: { projectId: route.params.projectId } }))
+        router.push(localePath({
+          name: 'dcis-projects',
+          query: { deleteProjectId: route.params.projectId }
+        }))
       }
     }
 

--- a/client/pages/dcis/projects/index.vue
+++ b/client/pages/dcis/projects/index.vue
@@ -70,8 +70,8 @@ export default defineComponent({
     } = useProjects()
 
     onMounted(() => {
-      if (route.query.projectId) {
-        deleteUpdate(defaultClient.cache, { data: { deleteProject: { id: route.query.projectId } } })
+      if (projects.value && projects.value.length && route.query.deleteProjectId) {
+        deleteUpdate(defaultClient.cache, { data: { deleteProject: { id: route.query.deleteProjectId } } })
         router.push(localePath({ name: 'dcis-projects' }))
       }
     })


### PR DESCRIPTION
Closes #606.
Проблема возникала в том случае, если переход из настроек после удаления осуществлялся до открытия таблицы. Тогда происходила попытка прочитать еще отсутствующий запрос из кеша.