### PR TITLE
Исправлена ошибка добавления периода

### DIFF
--- a/server/apps/dcis/services/excel_extractor_services.py
+++ b/server/apps/dcis/services/excel_extractor_services.py
@@ -228,8 +228,9 @@ class ExcelExtractor:
             if color.index == 64 or color.index == 65:
                 color = None
             else:
+                index = color.index
                 color.type = 'rgb'
-                color.value = COLOR_INDEX[color.index]
+                color.value = COLOR_INDEX[index]
         if color and color.type == 'theme':
             color.type = 'rgb'
             color.value = theme_and_tint_to_rgb(wb, color.theme, color.tint)


### PR DESCRIPTION
color.index - геттер, который после изменения color.type начинает выдавать объект RGB. Не очень понял как там формируется этот объект внутри, и почему эта проблема не вылезла раньше, но такая простая правка исправила проблему.