### PR TITLE
Исправлена проблема с фиксацией строк и столбцов при наличии ячеек с rowspan

### DIFF
--- a/client/components/dcis/grid/Grid.vue
+++ b/client/components/dcis/grid/Grid.vue
@@ -433,7 +433,6 @@ div.grid__body
 
         tr.grid__row_fixed
           position: sticky
-          z-index: 2
 
         td.grid__cell_fixed
           position: sticky

--- a/client/components/dcis/grid/GridBody.vue
+++ b/client/components/dcis/grid/GridBody.vue
@@ -59,7 +59,7 @@ import {
   RowDimensionType,
   SheetType
 } from '~/types/graphql'
-import { GridMode, ResizingType, FixedInfoType } from '~/types/grid'
+import { GridMode, ResizingType, FixedInfoType, RowFixedInfoType } from '~/types/grid'
 import { positionsToRangeIndices } from '~/services/grid'
 import { useAuthStore } from '~/stores'
 import GridRowControl from '~/components/dcis/grid/controls/GridRowControl.vue'
@@ -70,7 +70,7 @@ export default defineComponent({
   props: {
     resizingRow: { type: Object as PropType<ResizingType<RowDimensionType>>, default: null },
     getRowHeight: { type: Function as PropType<(row: RowDimensionType) => number>, required: true },
-    getRowFixedInfo: { type: Function as PropType<(row: RowDimensionType) => FixedInfoType>, required: true },
+    getRowFixedInfo: { type: Function as PropType<(row: RowDimensionType) => RowFixedInfoType>, required: true },
     getCellFixedInfo: { type: Function as PropType<(cell: CellType) => FixedInfoType>, required: true },
     borderFixedColumn: { type: Object as PropType<ColumnDimensionType>, default: null },
     borderFixedRow: { type: Object as PropType<RowDimensionType>, default: null },
@@ -122,7 +122,10 @@ export default defineComponent({
       }
       const fixedInfo = props.getRowFixedInfo(row)
       if (fixedInfo.fixed) {
-        return { top: `${fixedInfo.position}px` }
+        return {
+          top: `${fixedInfo.position}px`,
+          zIndex: `${2 + fixedInfo.reverseIndex}`
+        }
       }
       return {}
     }

--- a/client/types/grid.ts
+++ b/client/types/grid.ts
@@ -133,6 +133,10 @@ export type FixedInfoType = {
   position: number | null
 }
 
+export type RowFixedInfoType = FixedInfoType & {
+  reverseIndex: number | null
+}
+
 export type CellsOptionsType = {
   cells: CellType[]
   strong: boolean | null


### PR DESCRIPTION
Проблема заключалась в том, что верхняя строка перекрывала нижнюю, поскольку у них был одинаковый z-index.  Для ячеек с colspan подобная проблема не наблюдается.