### PR TITLE
Поправлена нумерация строк и столбцов

### DIFF
--- a/server/apps/dcis/services/excel_extractor_services.py
+++ b/server/apps/dcis/services/excel_extractor_services.py
@@ -260,7 +260,7 @@ class ExcelExtractor:
                 cells.append(BuildCell(
                     column_id=cell.column,
                     row_id=cell.row,
-                    kind=cell.data_type,
+                    kind=self._get_cell_kind(cell),
                     editable=not self.readonly_fill_color or fill_color.value == '00000000',
                     coordinate=cell.coordinate,
                     formula=cell.value if isinstance(cell.value, str) and cell.value and cell.value[0] == '=' else None,
@@ -307,3 +307,14 @@ class ExcelExtractor:
     def coordinate(sheet: str, column: int, row: int):
         """Получаем координату."""
         return f'{sheet}!{get_column_letter(column)}{row}'
+
+    @staticmethod
+    def _get_cell_kind(cell: OpenpyxlCell) -> str:
+        """Получение типа ячейки.
+
+        Если в Excel пометить ячейку с числом текстовым форматом, то он не изменят тип ячейки на 's',
+        а устанавливает number_format в значение '@', где @ - placeholder for text.
+        """
+        if cell.data_type == 'n' and cell.number_format == '@':
+            return 's'
+        return cell.data_type

--- a/server/apps/dcis/services/excel_extractor_services.py
+++ b/server/apps/dcis/services/excel_extractor_services.py
@@ -312,7 +312,7 @@ class ExcelExtractor:
     def _get_cell_kind(cell: OpenpyxlCell) -> str:
         """Получение типа ячейки.
 
-        Если в Excel пометить ячейку с числом текстовым форматом, то он не изменят тип ячейки на 's',
+        Если в Excel пометить ячейку с числом текстовым форматом, то он не изменяет тип ячейки на 's',
         а устанавливает number_format в значение '@', где @ - placeholder for text.
         """
         if cell.data_type == 'n' and cell.number_format == '@':


### PR DESCRIPTION
Closes #792.
Более того, если в ячейку с числом и типом "Текстовый" дописать еще что-то, а потом удалить, то тип меняется.
Т.е. 5 с типом текст - это 'n' и '@', а если сделать последовательно преобразование 5 -> 5aaaaa -> 5, то это уже 's'. И когда оно стало 's' обратно его превратить в 'n' c '@' не выходит. Преобразование типа 'Текстовый' -> 'Числовой' -> 'Текстовый' ничего не меняет. Я смотрел xml, и там после изменения  5 -> 5aaaaa, строка 5aaaaa попадает в файл sharedString, и видимо после изменения обратно на 5 оттуда не удаляется и тип 's' остается явно указанным прям в xml. В общем бред какой-то)