### PR TITLE
Исправлено отображение кавычек в атрибутах

### DIFF
--- a/server/apps/dcis/services/attribute_service.py
+++ b/server/apps/dcis/services/attribute_service.py
@@ -5,6 +5,7 @@ from typing import Sequence, cast
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.template import Context, Template
+from django.utils.safestring import mark_safe
 
 from apps.core.models import User
 from apps.dcis.models import Attribute, AttributeValue, Cell, Document, Value
@@ -67,13 +68,13 @@ def create_attribute_context(user: User, document: Document) -> Context:
         for attribute_value in AttributeValue.objects.filter(document=document).values('attribute_id', 'value')
     }
     context: dict[str, str] = {
-        attribute.key: attribute_values.get(attribute.id, attribute.default)
+        attribute.key: mark_safe(attribute_values.get(attribute.id, attribute.default))
         for attribute in attributes
     }
     # Расширяем контекст с помощью встроенных переменных
     context.update({
-        'user': user.get_full_name,
-        'org_id': document.object_id,
-        'org_name': document.object_name
+        'user': mark_safe(user.get_full_name),
+        'org_id': mark_safe(document.object_id),
+        'org_name': mark_safe(document.object_name)
     })
     return Context(context)

--- a/server/apps/dcis/services/cell_service.py
+++ b/server/apps/dcis/services/cell_service.py
@@ -1,13 +1,15 @@
 """Модуль, отвечающий за работу с метаданными ячейки."""
 import contextlib
 
-from django.db.models import QuerySet, Q, ExpressionWrapper
+from devind_helpers.orm_utils import get_object_or_404
 from devind_helpers.schema.types import ErrorFieldType
 from devind_helpers.utils import gid2int
-from devind_helpers.orm_utils import get_object_or_404
+from django.db.models import QuerySet
+
 from apps.core.models import User
-from apps.dcis.permissions import can_change_period_sheet
 from apps.dcis.models import Cell, Period, RelationshipCells
+from apps.dcis.permissions import can_change_period_sheet
+
 
 CellIDType = int | str
 
@@ -21,9 +23,9 @@ def check_cell_permission(user: User, cell_id: CellIDType) -> Cell:
 
 
 def add_cell_aggregation(
-        user: User,
-        cell_id: CellIDType,
-        cells_id: list[CellIDType]
+    user: User,
+    cell_id: CellIDType,
+    cells_id: list[CellIDType]
 ) -> tuple[list[Cell] | QuerySet[Cell], list[ErrorFieldType]]:
     """Добавляем ячейки к агрегирующей ячейке."""
     cell: Cell = check_cell_permission(user, cell_id)


### PR DESCRIPTION
Closes #993.
Для исправления базы:
```python
from apps.dcis.models import Document
from apps.dcis.services.attribute_service import rerender_values, create_attribute_context
for document in Document.objects.filter(value__column__cell__is_template=True):
    context = create_attribute_context(document.user, document)
    rerender_values(document, context)
```